### PR TITLE
checking for 'Level-3_Binned_Data' group in getDecodeQualification

### DIFF
--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L3ProductReaderPlugIn.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L3ProductReaderPlugIn.java
@@ -103,6 +103,10 @@ public class L3ProductReaderPlugIn implements ProductReaderPlugIn {
                 ncfile = NetcdfFile.open(file.getPath());
                 Attribute titleAttribute = ncfile.findGlobalAttributeIgnoreCase("Title");
 
+                if (ncfile.findGroup("Level-3_Binned_Data") == null) {
+                    return DecodeQualification.UNABLE;
+                }
+
                 List<Variable> seadasMappedVariables = ncfile.getVariables();
                 Boolean isSeadasMapped = false;
                 try {


### PR DESCRIPTION
Hi there,

We have made this change to your L3ProductReaderPlugIn. The _getDecodeQualification()_ now checks if the group "Level-3_Binned_Data" exists. This is what the _L3BinFileReader_ requires.

We discovered the problem because your reader tried to read on of our product we have in our test data set but it failed because the group didn't exist. The product is a "SeaDAS-Level3-a-like" product. and we have our own reader for this.

Would be great if you can take this over into your code repository.
